### PR TITLE
Enable real-time chat functionality with WebSocket broadcasting

### DIFF
--- a/AdminPanel/config/app.php
+++ b/AdminPanel/config/app.php
@@ -191,7 +191,7 @@ return [
          */
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
-        // App\Providers\BroadcastServiceProvider::class,
+        App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 

--- a/AdminPanel/config/broadcasting.php
+++ b/AdminPanel/config/broadcasting.php
@@ -65,6 +65,20 @@ return [
             'driver' => 'null',
         ],
 
+        'websockets' => [
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY'),
+            'secret' => env('PUSHER_APP_SECRET'),
+            'app_id' => env('PUSHER_APP_ID'),
+            'options' => [
+                'host' => env('PUSHER_HOST', '127.0.0.1'),
+                'port' => env('PUSHER_PORT', 6001),
+                'scheme' => env('PUSHER_SCHEME', 'http'),
+                'encrypted' => false,
+                'useTLS' => false,
+            ],
+        ],
+
     ],
 
 ];

--- a/AdminPanel/database/migrations/0000_00_00_000000_rename_statistics_counters.php
+++ b/AdminPanel/database/migrations/0000_00_00_000000_rename_statistics_counters.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameStatisticsCounters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
+            $table->renameColumn('peak_connection_count', 'peak_connections_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
+            $table->renameColumn('websocket_message_count', 'websocket_messages_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
+            $table->renameColumn('api_message_count', 'api_messages_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
+            $table->renameColumn('peak_connections_count', 'peak_connection_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
+            $table->renameColumn('websocket_messages_count', 'websocket_message_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
+            $table->renameColumn('api_messages_count', 'api_message_count');
+        });
+    }
+}


### PR DESCRIPTION
- Enabled BroadcastServiceProvider in config/app.php
- Added 'websockets' connection to broadcasting config using Pusher protocol
- Published laravel-websockets migration files
- Configured for local WebSocket server on port 6001

This enables real-time message broadcasting for the chat feature. Users can now receive messages instantly without page refresh.